### PR TITLE
Win98 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.c text eol=crlf
+*.h text eol=crlf
+*.dsp text eol=crlf
+*.rc text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+*.lk1
+*.err
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb

--- a/src/esdev.c
+++ b/src/esdev.c
@@ -23,6 +23,7 @@
 
 DWORD EnumESSDevices(HWND hWnd, void (*EnumCB)(ESS_DEVCFG *pCfg, void *pUser), void *pUser)
 {
+#ifdef CM_Free_Log_Conf_Handle 
 	GUID render = KSCATEGORY_RENDER;
 	HDEVINFO hDevInfo;
 	SP_DEVINFO_DATA infoData={0};
@@ -92,5 +93,8 @@ DWORD EnumESSDevices(HWND hWnd, void (*EnumCB)(ESS_DEVCFG *pCfg, void *pUser), v
 		}
 	}
 	return ret;
+#else
+	return 0;
+#endif
 }
 

--- a/src/esfmbank.c
+++ b/src/esfmbank.c
@@ -25,6 +25,21 @@
 #pragma comment (lib, "winmm.lib")
 #pragma comment (lib, "shlwapi.lib")
 
+#ifndef DWORD_PTR
+typedef unsigned long DWORD_PTR;
+#endif
+
+// VC6 workaround
+static HWND GetRoot(HWND hwnd) {
+	HWND root = NULL;
+	HWND parent = hwnd;
+
+	while((parent = GetParent(parent)) != NULL) {
+		root = parent;
+	}
+
+	return root;
+}
 
 #pragma pack(1)
 typedef struct
@@ -614,7 +629,7 @@ LRESULT CALLBACK OperatorDlgProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM 
 			case IDCANCEL:
 				if (HIWORD(wParam) == BN_CLICKED)
 				{
-					HWND hWndRoot = GetAncestor(hWnd, GA_ROOT);
+					HWND hWndRoot = GetRoot(hWnd);
 					iCurSel = GetCurrentInstrument(hWndRoot);
 					if (iCurSel != LB_ERR)
 					{
@@ -628,7 +643,7 @@ LRESULT CALLBACK OperatorDlgProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM 
 			case IDC_FP:
 				if (HIWORD(wParam) == BN_CLICKED)
 				{
-						HWND hWndRoot = GetAncestor(hWnd, GA_ROOT);
+						HWND hWndRoot = GetRoot(hWnd);
 						ChangeFixedPitch(hWnd, (HWND) lParam);
 						iCurSel = GetCurrentInstrument(hWndRoot);
 						ResetFNUM(hWnd, &m_patches.patches[iCurSel]);

--- a/src/esfmbank.dsp
+++ b/src/esfmbank.dsp
@@ -1,25 +1,25 @@
 # Microsoft Developer Studio Project File - Name="esfmbank" - Package Owner=<4>
 # Microsoft Developer Studio Generated Build File, Format Version 6.00
-# ** NICHT BEARBEITEN **
+# ** DO NOT EDIT **
 
 # TARGTYPE "Win32 (x86) Application" 0x0101
 
 CFG=esfmbank - Win32 Debug
-!MESSAGE Dies ist kein gültiges Makefile. Zum Erstellen dieses Projekts mit NMAKE
-!MESSAGE verwenden Sie den Befehl "Makefile exportieren" und führen Sie den Befehl
+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
+!MESSAGE use the Export Makefile command and run
 !MESSAGE 
 !MESSAGE NMAKE /f "esfmbank.mak".
 !MESSAGE 
-!MESSAGE Sie können beim Ausführen von NMAKE eine Konfiguration angeben
-!MESSAGE durch Definieren des Makros CFG in der Befehlszeile. Zum Beispiel:
+!MESSAGE You can specify a configuration when running NMAKE
+!MESSAGE by defining the macro CFG on the command line. For example:
 !MESSAGE 
 !MESSAGE NMAKE /f "esfmbank.mak" CFG="esfmbank - Win32 Debug"
 !MESSAGE 
-!MESSAGE Für die Konfiguration stehen zur Auswahl:
+!MESSAGE Possible choices for configuration are:
 !MESSAGE 
-!MESSAGE "esfmbank - Win32 Release" (basierend auf  "Win32 (x86) Application")
-!MESSAGE "esfmbank - Win32 Debug" (basierend auf  "Win32 (x86) Application")
-!MESSAGE "esfmbank - Win32 Release x64" (basierend auf  "Win32 (x86) Application")
+!MESSAGE "esfmbank - Win32 Release" (based on "Win32 (x86) Application")
+!MESSAGE "esfmbank - Win32 Debug" (based on "Win32 (x86) Application")
+!MESSAGE "esfmbank - Win32 Release x64" (based on "Win32 (x86) Application")
 !MESSAGE 
 
 # Begin Project
@@ -44,7 +44,7 @@ RSC=rc.exe
 # PROP Ignore_Export_Lib 0
 # PROP Target_Dir ""
 # ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /YX /FD /c
-# ADD CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /YX /FD /c
+# ADD CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_WINDOWS" /FR /YX /FD /c
 # ADD BASE MTL /nologo /D "NDEBUG" /mktyplib203 /win32
 # ADD MTL /nologo /D "NDEBUG" /mktyplib203 /win32
 # ADD BASE RSC /l 0xc07 /d "NDEBUG"

--- a/src/esfmbank.dsw
+++ b/src/esfmbank.dsw
@@ -1,9 +1,9 @@
 Microsoft Developer Studio Workspace File, Format Version 6.00
-# WARNUNG: DIESE ARBEITSBEREICHSDATEI DARF NICHT BEARBEITET ODER GELÖSCHT WERDEN!
+# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
 
 ###############################################################################
 
-Project: "esfmbank"=".\esfmbank.dsp" - Package Owner=<4>
+Project: "esfmbank"=.\esfmbank.dsp - Package Owner=<4>
 
 Package=<5>
 {{{

--- a/src/res.rc
+++ b/src/res.rc
@@ -13,7 +13,7 @@
 #undef APSTUDIO_READONLY_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
-// Deutsch (Deutschland) resources
+// German (Germany) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_DEU)
 #ifdef _WIN32
@@ -29,7 +29,7 @@ LANGUAGE LANG_GERMAN, SUBLANG_GERMAN
 IDD_PROPPAGE_OPERATOR DIALOGEX 0, 0, 196, 204
 STYLE WS_CHILD
 EXSTYLE WS_EX_CONTROLPARENT
-FONT 8, "MS Sans Serif"
+FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
     LTEXT           "Attack:",IDC_STATIC,4,5,30,9
     EDITTEXT        IDC_ATTACK,35,3,23,12,ES_AUTOHSCROLL | ES_NUMBER
@@ -121,7 +121,7 @@ END
 IDD_PROPPAGE_VOICES DIALOGEX 0, 0, 211, 236
 STYLE WS_CHILD
 EXSTYLE WS_EX_CONTROLPARENT
-FONT 8, "MS Sans Serif"
+FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
     CONTROL         "Use channel 16+17",IDC_PAT16,"Button",BS_AUTOCHECKBOX | 
                     WS_TABSTOP,0,1,99,10
@@ -146,12 +146,12 @@ BEGIN
 END
 #endif    // APSTUDIO_INVOKED
 
-#endif    // Deutsch (Deutschland) resources
+#endif    // German (Germany) resources
 /////////////////////////////////////////////////////////////////////////////
 
 
 /////////////////////////////////////////////////////////////////////////////
-// Deutsch (Österreich) resources
+// German (Austria) resources
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_DEA)
 #ifdef _WIN32
@@ -364,7 +364,7 @@ BEGIN
     IDM_EXIT                "Exits the application"
 END
 
-#endif    // Deutsch (Österreich) resources
+#endif    // German (Austria) resources
 /////////////////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
* Force CRLF for Visual Studio 6 project files and sources so it opens in Windows 98.
* Remove device polling when unsupported. The functions for this were not defined in the Windows 98 DDK.
* Replace `GetAncestor` with custom `GetRoot` function.

Known Issues:
* Clicking the "Percussion" radio button causes the application to freeze my system. I couldn't find where the issue is since my system would lock up before I was able to pause the debugger. Not sure if this is also an issue other Windows versions.